### PR TITLE
Add functionality to syndicate stories

### DIFF
--- a/butterfli.gemspec
+++ b/butterfli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.3"
+  s.add_development_dependency "rspec-collection_matchers", "~> 1.1.2"
   s.add_development_dependency "pry", "~> 0.10.1"
   s.add_development_dependency "pry-stack_explorer", "~> 0.4.9"
   s.add_development_dependency "yard", "~> 0.8.7.6"

--- a/lib/butterfli.rb
+++ b/lib/butterfli.rb
@@ -1,6 +1,8 @@
 require "butterfli/version"
 require "butterfli/configuration"
 
+require 'butterfli/observable'
+
 require 'butterfli/story/schemable'
 require 'butterfli/story/authorable'
 require 'butterfli/story/taggable'

--- a/lib/butterfli/observable.rb
+++ b/lib/butterfli/observable.rb
@@ -1,0 +1,54 @@
+module Butterfli::Observable
+  class Subscription < Hash
+    def initialize(options = {})
+      t = options[:types] || []
+      t = [t] if !t.is_a?(Array)
+      self.merge!(options.merge(types: t))
+    end
+    def types
+      self[:types] ||= []
+    end
+    def block
+      self[:block]
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+  
+  module ClassMethods
+    def subscriptions
+      @subscriptions ||= {}
+    end
+    def subscribe(options = {}, &block)
+      new_subscription = Butterfli::Observable::Subscription.new(types: options[:to], block: block)
+      key = block.object_id
+      subscriptions[key] = new_subscription
+      key
+    end
+    def syndicate(*stories)
+      stories = stories.flatten
+      if !stories.empty?
+        story_groups = stories.group_by { |s| s.type }
+        subscriptions.values.each do |subscription|
+          if subscription.types.empty?
+            # Then send everything
+            stories_to_send = story_groups.values.flatten
+          else
+            # Only send matching types
+            stories_to_send = subscription.types.inject([]) do |result, type|
+              result.concat(story_groups[type]) if story_groups.has_key?(type)
+              result
+            end
+          end
+          subscription.block.call(stories_to_send) if !stories_to_send.empty?
+        end
+      end
+      stories
+    end
+    def unsubscribe_all
+      @subscriptions = {}
+    end
+  end
+end

--- a/spec/butterfli/observable_spec.rb
+++ b/spec/butterfli/observable_spec.rb
@@ -1,0 +1,204 @@
+require 'spec_helper'
+
+RSpec.shared_examples "an observable #subscribe call" do
+  it { expect(subject).to be_a_kind_of(Fixnum) }
+  it { expect(subject).to eq(subscription.object_id) }
+end
+
+describe Butterfli::Observable do
+  let(:observable_class) do
+    stub_const 'Instabook', Module.new
+    Instabook.class_eval { include Butterfli::Observable }
+    Instabook
+  end
+  subject { observable_class }
+  # Make sure subscriber list is always clean
+  # before(:each) { subject.unsubscribe_all }
+
+  describe "#subscriptions" do
+    subject { super().subscriptions }
+    context "when nothing has subscribed" do
+      it { expect(subject).to be_empty }
+    end
+    context "when something has subscribed" do
+      before(:each) { observable_class.subscribe { puts "Story received." } }
+      it { expect(subject).to have(1).items }
+    end
+  end
+  describe "subscription (subscribe/syndicate)" do
+    let(:target) { double("target") }
+    let(:subscription) { Proc.new { |stories| target.share(stories) } }
+
+    # Invoke #subscribe before each example
+    before(:each) do
+      subject 
+    end
+    
+    context "when setup with only a block" do
+      subject do
+        super().subscribe &subscription
+      end
+
+      it_behaves_like "an observable #subscribe call"
+      
+      context "and a single story is syndicated" do
+        let(:story) { Butterfli::Story.new.merge!(type: :image) }
+        it do
+          expect(target).to receive(:share).with([story])
+          observable_class.syndicate(story)
+        end
+      end
+      context "and multiple stories" do
+        let(:stories) { [story_one, story_two] }
+        context "all of same type are syndicated" do
+          let(:story_one) { Butterfli::Story.new.merge!(type: :image) }
+          let(:story_two) { Butterfli::Story.new.merge!(type: :image) }
+          it do
+            expect(target).to receive(:share).with(stories)
+            observable_class.syndicate(stories)
+          end
+        end
+        context "none of same type are syndicated" do
+          let(:story_one) { Butterfli::Story.new.merge!(type: :image) }
+          let(:story_two) { Butterfli::Story.new.merge!(type: :video) }
+          it do
+            expect(target).to receive(:share).with(stories)
+            observable_class.syndicate(stories)
+          end
+        end
+      end
+    end
+    context "when setup with a block and" do
+      context "a type to listen for" do
+        let(:subscription_type) { :image }
+        let(:other_subscription_type) { :video }
+        subject do
+          super().subscribe to: subscription_type, &subscription
+        end
+
+        it_behaves_like "an observable #subscribe call"
+
+        context "and a single story" do
+          context "of matching type is syndicated" do
+            let(:story) { Butterfli::Story.new.merge!(type: subscription_type) }
+            it do
+              expect(target).to receive(:share).with([story])
+              observable_class.syndicate(story)
+            end
+          end
+          context "of non-matching type is syndicated" do
+            let(:story) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            it do
+              expect(target).to_not receive(:share)
+              observable_class.syndicate(story)
+            end
+          end
+        end
+        context "and multiple stories" do
+          context "all of matching type are syndicated" do
+            let(:matching_story_one) { Butterfli::Story.new.merge!(type: subscription_type) }
+            let(:matching_story_two) { Butterfli::Story.new.merge!(type: subscription_type) }
+            let(:stories) { [matching_story_one, matching_story_two] }
+            it do
+              expect(target).to receive(:share).with(stories)
+              observable_class.syndicate(stories)
+            end
+          end
+          context "some of matching type are syndicated" do
+            let(:matching_story) { Butterfli::Story.new.merge!(type: subscription_type) }
+            let(:non_matching_story) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:stories) { [matching_story, non_matching_story] }
+            it do
+              expect(target).to receive(:share).with([matching_story])
+              observable_class.syndicate(stories)
+            end
+          end
+          context "none of matching type are syndicated" do
+            let(:non_matching_story_one) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:non_matching_story_two) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:stories) { [non_matching_story_one, non_matching_story_two] }
+            it do
+              expect(target).to_not receive(:share)
+              observable_class.syndicate(stories)
+            end
+          end
+        end
+      end
+      context "multiple types to listen for" do
+        let(:subscription_types) { [:image, :video] }
+        let(:other_subscription_type) { :audio }
+        subject do
+          super().subscribe to: subscription_types, &subscription
+        end
+
+        it_behaves_like "an observable #subscribe call"
+
+        context "and a single story" do
+          context "of matching type is syndicated" do
+            let(:story) { Butterfli::Story.new.merge!(type: subscription_types.first) }
+            it do
+              expect(target).to receive(:share).with([story])
+              observable_class.syndicate(story)
+            end
+          end
+          context "of non-matching type is syndicated" do
+            let(:story) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            it do
+              expect(target).to_not receive(:share)
+              observable_class.syndicate(story)
+            end
+          end
+        end
+        context "and multiple stories" do
+          context "all of matching type are syndicated" do
+            let(:matching_story_one) { Butterfli::Story.new.merge!(type: subscription_types.first) }
+            let(:matching_story_two) { Butterfli::Story.new.merge!(type: subscription_types.last) }
+            let(:stories) { [matching_story_one, matching_story_two] }
+            it do
+              expect(target).to receive(:share).with(stories)
+              observable_class.syndicate(stories)
+            end
+          end
+          context "some of matching type are syndicated" do
+            let(:matching_story) { Butterfli::Story.new.merge!(type: subscription_types.first) }
+            let(:non_matching_story) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:stories) { [matching_story, non_matching_story] }
+            it do
+              expect(target).to receive(:share).with([matching_story])
+              observable_class.syndicate(stories)
+            end
+          end
+          context "none of matching type are syndicated" do
+            let(:non_matching_story_one) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:non_matching_story_two) { Butterfli::Story.new.merge!(type: other_subscription_type) }
+            let(:stories) { [non_matching_story_one, non_matching_story_two] }
+            it do
+              expect(target).to_not receive(:share)
+              observable_class.syndicate(stories)
+            end
+          end
+        end
+      end
+    end
+  end
+  describe "#unsubscribe" do
+    # TODO: Fill this in if ever implemented.
+  end
+  describe "#unsubscribe_all" do
+    context "when there are active subscriptions" do
+      let(:target) { double("target") }
+      let(:subscription) { Proc.new { |stories| target.share(stories) } }
+      subject { super().unsubscribe_all }
+
+      before(:each) do
+        observable_class.subscribe &subscription
+      end
+
+      it do
+        expect(observable_class.subscriptions).to have(1).items
+        subject
+        expect(observable_class.subscriptions).to be_empty
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH << File.join(File.dirname(__FILE__))
 
 require 'rubygems'
 require 'pry'
+require 'rspec/collection_matchers'
 
 require 'butterfli'
 


### PR DESCRIPTION
This pull request adds an `Observable` module that allows developers to subscribe to and syndicate stories across their application.

1 - Extend any class or module with `Observable`:

``` ruby
module Instabook
  include Butterfli::Observable
end
```

2 - Subscribe to the module to 'listen' for new stories:

``` ruby
Instabook.subscribe do |stories|
  puts "I received #{stories.length} stories!"
end
# You can also limit the kinds of stories you listen to
# Only listen to :image stories
Instabook.subscribe to: :image do |stories|
  puts "I received #{stories.length} image stories!"
end
# Only listen to both :image and :video stories
Instabook.subscribe to: [:image, :video] do |stories|
  puts "I received #{stories.length} image and video stories!"
end
```

3 - Share stories to these 'listeners':

``` ruby
stories = [Butterfli::Story.new, Butterfli::Story.new]
Instabook.syndicate(stories)
# "I received 2 stories!"
Instabook.syndicate(Butterfli::Story.new)
# "I received 1 stories!"
```
