### PR TITLE
Add cache layer

### DIFF
--- a/lib/butterfli.rb
+++ b/lib/butterfli.rb
@@ -30,6 +30,9 @@ require 'butterfli/configuration/writers/syndicate_writer'
 require 'butterfli/caching/cache'
 require 'butterfli/caching'
 
+require 'butterfli/caching/memory_cache_adapter'
+require 'butterfli/configuration/caches/memory_cache'
+
 require 'butterfli/jobs/job'
 require 'butterfli/jobs/story_job'
 

--- a/lib/butterfli.rb
+++ b/lib/butterfli.rb
@@ -27,6 +27,9 @@ require 'butterfli/writing'
 require 'butterfli/writing/syndicate_writer'
 require 'butterfli/configuration/writers/syndicate_writer'
 
+require 'butterfli/caching/cache'
+require 'butterfli/caching'
+
 require 'butterfli/jobs/job'
 require 'butterfli/jobs/story_job'
 

--- a/lib/butterfli/caching.rb
+++ b/lib/butterfli/caching.rb
@@ -1,0 +1,17 @@
+module Butterfli::Caching
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+  
+  module ClassMethods
+    def cache=(p)
+      @cache = p
+    end
+    def cache
+      return @cache || (self.cache = ( Butterfli.configuration.cache && Butterfli.configuration.cache.instantiate))
+    end
+  end
+end
+
+# Inject module into the global namespace
+Butterfli.class_eval { include Butterfli::Caching }

--- a/lib/butterfli/caching/cache.rb
+++ b/lib/butterfli/caching/cache.rb
@@ -1,0 +1,28 @@
+class Butterfli::Cache
+  attr_accessor :adapter
+  def initialize(adapter)
+    self.adapter = adapter
+  end
+
+  def read(key)
+    self.adapter.read(key)
+  end
+  def write(key, value)
+    self.adapter.write(key, value)
+  end
+  def fetch(key, value = nil, &block)
+    self.adapter.fetch(key, value, &block)
+  end
+  def delete(key)
+    self.adapter.delete(key)
+  end
+  def clear
+    self.adapter.clear
+  end
+  def has_key?(key)
+    self.adapter.has_key?(key)
+  end
+  def empty?
+    self.adapter.empty?
+  end
+end

--- a/lib/butterfli/caching/cache.rb
+++ b/lib/butterfli/caching/cache.rb
@@ -10,8 +10,11 @@ class Butterfli::Cache
   def write(key, value)
     self.adapter.write(key, value)
   end
-  def fetch(key, value = nil, &block)
-    self.adapter.fetch(key, value, &block)
+  def fetch(key, value)
+    self.adapter.fetch(key, value)
+  end
+  def lazy_fetch(key, &block)
+    self.adapter.lazy_fetch(key, &block)
   end
   def delete(key)
     self.adapter.delete(key)

--- a/lib/butterfli/caching/memory_cache_adapter.rb
+++ b/lib/butterfli/caching/memory_cache_adapter.rb
@@ -10,8 +10,11 @@ class Butterfli::MemoryCacheAdapter
   def write(key, value)
     self.memory_cache[key] = value
   end
-  def fetch(key, value = nil, &block)
-    self.memory_cache.has_key?(key) ? self.memory_cache[key] : (self.memory_cache[key] = (value || block.call))
+  def fetch(key, value)
+    self.memory_cache.has_key?(key) ? self.memory_cache[key] : (self.memory_cache[key] = value)
+  end
+  def lazy_fetch(key, &block)
+    self.memory_cache.has_key?(key) ? self.memory_cache[key] : (self.memory_cache[key] = block.call)
   end
   def delete(key)
     self.memory_cache.delete(key)

--- a/lib/butterfli/caching/memory_cache_adapter.rb
+++ b/lib/butterfli/caching/memory_cache_adapter.rb
@@ -1,0 +1,28 @@
+class Butterfli::MemoryCacheAdapter
+  attr_accessor :memory_cache
+  def initialize(options = {})
+    self.memory_cache = {}
+  end
+
+  def read(key)
+    self.memory_cache[key]
+  end
+  def write(key, value)
+    self.memory_cache[key] = value
+  end
+  def fetch(key, value = nil, &block)
+    self.memory_cache.has_key?(key) ? self.memory_cache[key] : (self.memory_cache[key] = (value || block.call))
+  end
+  def delete(key)
+    self.memory_cache.delete(key)
+  end
+  def clear
+    self.memory_cache.clear
+  end
+  def has_key?(key)
+    self.memory_cache.has_key?(key)
+  end
+  def empty?
+    self.memory_cache.empty?
+  end
+end

--- a/lib/butterfli/configuration.rb
+++ b/lib/butterfli/configuration.rb
@@ -1,6 +1,7 @@
 require 'butterfli/configuration/provisioning'
 require 'butterfli/configuration/observing'
 require 'butterfli/configuration/writing'
+require 'butterfli/configuration/caching'
 require 'butterfli/configuration/processing'
 
 module Butterfli

--- a/lib/butterfli/configuration/caches/memory_cache.rb
+++ b/lib/butterfli/configuration/caches/memory_cache.rb
@@ -1,0 +1,7 @@
+class Butterfli::Configuration::MemoryCache < Butterfli::Configuration::Cache
+end
+
+# Add it to the known caches list...
+Butterfli::Configuration::Caches.register_cache(:memory,
+                                                Butterfli::Configuration::MemoryCache,
+                                                Butterfli::MemoryCacheAdapter)

--- a/lib/butterfli/configuration/caching.rb
+++ b/lib/butterfli/configuration/caching.rb
@@ -1,0 +1,46 @@
+module Butterfli
+  module Configuration
+    class Cache
+      attr_accessor :instance_class
+      def initialize(options = {})
+        self.instance_class = options[:instance_class]
+      end
+      def instantiate
+        Butterfli::Cache.new(self.instance_class.new(options))
+      end
+      def options
+        { }
+      end
+    end
+
+    module Writing
+      def cache(name = nil, &block)
+        if !name.nil?
+          new_cache = Butterfli::Configuration::Caches.instantiate_cache(name)
+          block.call(new_cache) if !block.nil?
+          @cache = new_cache
+        else
+          @cache
+        end
+      end
+    end
+
+    # Maintains a list of known caches which Butterfli can configure
+    module Caches
+      def self.known_caches
+        @known_caches ||= {}
+      end
+      def self.register_cache(name, config_class, instance_class)
+        self.known_caches[name.to_sym] = { configuration: config_class, instance: instance_class }
+      end
+      def self.instantiate_cache(name, options = {})
+        cache = self.known_caches[name.to_sym]
+        if cache
+          cache[:configuration].new(instance_class: cache[:instance])
+        else
+          raise "Unknown cache: #{name}!"
+        end
+      end
+    end
+  end
+end

--- a/lib/butterfli/configuration/processing.rb
+++ b/lib/butterfli/configuration/processing.rb
@@ -17,7 +17,7 @@ module Butterfli
       def processor(name = nil, &block)
         if !name.nil?
           new_processor = Butterfli::Configuration::Processors.instantiate_processor(name)
-          block.call(new_processor)
+          block.call(new_processor) if !block.nil?
           @processor = new_processor
         else
           @processor

--- a/lib/butterfli/configuration/processors/monolith_processor.rb
+++ b/lib/butterfli/configuration/processors/monolith_processor.rb
@@ -10,7 +10,7 @@ class Butterfli::Configuration::MonolithProcessor < Butterfli::Configuration::Pr
   end
 end
 
-# Add it to the known providers list...
+# Add it to the known processors list...
 Butterfli::Configuration::Processors.register_processor(:monolith,
                                                         Butterfli::Configuration::MonolithProcessor,
                                                         Butterfli::MonolithProcessor)

--- a/lib/butterfli/configuration/writers/syndicate_writer.rb
+++ b/lib/butterfli/configuration/writers/syndicate_writer.rb
@@ -1,7 +1,7 @@
 class Butterfli::Configuration::SyndicateWriter < Butterfli::Configuration::Writer
 end
 
-# Add it to the known providers list...
+# Add it to the known writers list...
 Butterfli::Configuration::Writers.register_writer(:syndicate,
                                                   Butterfli::Configuration::SyndicateWriter,
                                                   Butterfli::SyndicateWriter)

--- a/spec/butterfli/butterfli_spec.rb
+++ b/spec/butterfli/butterfli_spec.rb
@@ -23,4 +23,7 @@ describe Butterfli do
   context "as a writer" do
     it { expect(subject).to respond_to(:writers) }
   end
+  context "as a cache" do
+    it { expect(subject).to respond_to(:cache) }
+  end
 end

--- a/spec/butterfli/caching/cache_spec.rb
+++ b/spec/butterfli/caching/cache_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Butterfli::Cache do
+  let(:adapter) { double('adapter') }
+  let(:cache) { Butterfli::Cache.new(adapter) }
+
+  context "when initialized" do
+    it { expect(cache.adapter).to eq(adapter) }
+  end
+  context "#read" do
+    subject { cache.read(key) }
+    let(:key) { "key" }
+    it { expect(adapter).to receive(:read).with(key).exactly(1).times; subject }
+  end
+  context "#write" do
+    subject { cache.write(key, value) }
+    let(:key) { "key" }
+    let(:value) { "value" }
+    it { expect(adapter).to receive(:write).with(key, value).exactly(1).times; subject }
+  end
+  context "#fetch" do
+    subject { cache.fetch(key, value, &value_block) }
+    let(:key) { "key" }
+    let(:value) { "value" }
+    let(:value_block) { Proc.new { "block value" } }
+    # Rspec is kind of dumb: it doesn't know how to expect block arguments
+    it { expect(adapter).to receive(:fetch).with(key, value).exactly(1).times; subject }
+  end
+  context "#delete" do
+    subject { cache.delete(key) }
+    let(:key) { "key" }
+    it { expect(adapter).to receive(:delete).with(key).exactly(1).times; subject }
+  end
+  context "#clear" do
+    subject { cache.clear }
+    it { expect(adapter).to receive(:clear).exactly(1).times; subject }
+  end
+  context "#has_key?" do
+    subject { cache.has_key?(key) }
+    let(:key) { "key" }
+    it { expect(adapter).to receive(:has_key?).with(key).exactly(1).times; subject }
+  end
+  context "#empty?" do
+    subject { cache.empty? }
+    it { expect(adapter).to receive(:empty?).exactly(1).times; subject }
+  end
+end

--- a/spec/butterfli/caching/cache_spec.rb
+++ b/spec/butterfli/caching/cache_spec.rb
@@ -19,12 +19,17 @@ describe Butterfli::Cache do
     it { expect(adapter).to receive(:write).with(key, value).exactly(1).times; subject }
   end
   context "#fetch" do
-    subject { cache.fetch(key, value, &value_block) }
+    subject { cache.fetch(key, value) }
     let(:key) { "key" }
     let(:value) { "value" }
+    it { expect(adapter).to receive(:fetch).with(key, value).exactly(1).times; subject }
+  end
+  context "#lazy_fetch" do
+    subject { cache.lazy_fetch(key, &value_block) }
+    let(:key) { "key" }
     let(:value_block) { Proc.new { "block value" } }
     # Rspec is kind of dumb: it doesn't know how to expect block arguments
-    it { expect(adapter).to receive(:fetch).with(key, value).exactly(1).times; subject }
+    it { expect(adapter).to receive(:lazy_fetch).with(key).exactly(1).times; subject }
   end
   context "#delete" do
     subject { cache.delete(key) }

--- a/spec/butterfli/caching/memory_cache_adapter_spec.rb
+++ b/spec/butterfli/caching/memory_cache_adapter_spec.rb
@@ -29,30 +29,32 @@ describe Butterfli::Cache do
     end
   end
   context "#fetch" do
+    subject { adapter.fetch(key, value) }
     let(:key) { "key" }
     let(:value) { "value" }
+
+    context "invoked against existing key" do
+      let(:old_value) { "old_value" }
+      before(:each) { adapter.write(key, old_value) }
+      it { expect(subject).to eq(old_value) }
+    end
+    context "invoked against non-existent key" do
+      it { expect(subject).to eq(value) }
+    end
+  end
+  context "#lazy_fetch" do
+    subject { adapter.lazy_fetch(key, &block) }
+    let(:key) { "key" }
     let(:block_value) { "block value" }
     let(:block) { Proc.new { block_value } }
 
     context "invoked against existing key" do
       let(:old_value) { "old_value" }
       before(:each) { adapter.write(key, old_value) }
-      subject { adapter.fetch(key, value) }
       it { expect(subject).to eq(old_value) }
     end
     context "invoked against non-existent key" do
-      context "when passed a value" do
-        subject { adapter.fetch(key, value) }
-        it { expect(subject).to eq(value) }
-      end
-      context "when passed a block" do
-        subject { adapter.fetch(key, &block) }
-        it { expect(subject).to eq(block_value) }
-      end
-      context "when passed a value and block" do
-        subject { adapter.fetch(key, value, &block) }
-        it { expect(subject).to eq(value) }
-      end
+      it { expect(subject).to eq(block_value) }
     end
   end
   context "#delete" do

--- a/spec/butterfli/caching/memory_cache_adapter_spec.rb
+++ b/spec/butterfli/caching/memory_cache_adapter_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Butterfli::Cache do
+  let(:adapter) { Butterfli::MemoryCacheAdapter.new }
+  let(:memory_cache) { adapter.memory_cache }
+
+  context "when initialized" do
+    it { expect(memory_cache).to eq({}) }
+  end
+  context "#read" do
+    subject { adapter.read(key) }
+    let(:key) { "key" }
+    context "when the key exists in the cache" do
+      let(:value) { "value" }
+      before(:each) { adapter.write(key, value) }
+      it { expect(subject).to eq(value) }
+    end
+    context "when the key doesn't exists in the cache" do
+      it { expect(subject).to be nil }
+    end
+  end
+  context "#write" do
+    subject { adapter.write(key, value) }
+    let(:key) { "key" }
+    let(:value) { "value" }
+    it do
+      expect(subject).to eq(value)
+      expect(adapter.read(key)).to eq(value)
+    end
+  end
+  context "#fetch" do
+    let(:key) { "key" }
+    let(:value) { "value" }
+    let(:block_value) { "block value" }
+    let(:block) { Proc.new { block_value } }
+
+    context "invoked against existing key" do
+      let(:old_value) { "old_value" }
+      before(:each) { adapter.write(key, old_value) }
+      subject { adapter.fetch(key, value) }
+      it { expect(subject).to eq(old_value) }
+    end
+    context "invoked against non-existent key" do
+      context "when passed a value" do
+        subject { adapter.fetch(key, value) }
+        it { expect(subject).to eq(value) }
+      end
+      context "when passed a block" do
+        subject { adapter.fetch(key, &block) }
+        it { expect(subject).to eq(block_value) }
+      end
+      context "when passed a value and block" do
+        subject { adapter.fetch(key, value, &block) }
+        it { expect(subject).to eq(value) }
+      end
+    end
+  end
+  context "#delete" do
+    subject { adapter.delete(key) }
+    let(:key) { "key" }
+    let(:old_value) { "old_value" }
+    before(:each) { adapter.write(key, old_value) }
+    it do
+      expect(subject).to eq(old_value)
+      expect(adapter.has_key?(key)).to be false
+    end
+  end
+  context "#clear" do
+    subject { adapter.clear }
+    let(:key) { "key" }
+    let(:old_value) { "old_value" }
+    before(:each) { adapter.write(key, old_value) }
+    it do
+      expect(subject).to eq({})
+      expect(adapter.empty?).to be true
+    end
+  end
+  context "#has_key?" do
+    subject { adapter.has_key?(key) }
+    let(:key) { "key" }
+    context "invoked against existing key" do
+      before(:each) { adapter.write(key, 1) }
+      it { expect(subject).to be true }
+    end
+    context "invoked against non-existent key" do
+      it { expect(subject).to be false }
+    end
+  end
+  context "#empty?" do
+    subject { adapter.empty? }
+    context "invoked against non-empty cache" do
+      before(:each) { adapter.write("key", "value") }
+      it { expect(subject).to be false }
+    end
+    context "invoked against empty cache" do
+      it { expect(subject).to be true }
+    end
+  end
+end

--- a/spec/butterfli/configuration/cache_spec.rb
+++ b/spec/butterfli/configuration/cache_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Cache do
+  let(:cache) { Butterfli::Configuration::Cache.new }
+  subject { cache }
+end

--- a/spec/butterfli/configuration/caches/memory_cache_spec.rb
+++ b/spec/butterfli/configuration/caches/memory_cache_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::MemoryCache do
+  context "when configured within Butterfli" do
+    before do
+      Butterfli.cache = nil
+      Butterfli.configure do |config|
+        config.cache :memory
+      end
+    end
+    after { Butterfli.cache = nil; Butterfli.configure { } }
+    subject { Butterfli.cache.adapter }
+    it do
+      expect(subject).to be_a_kind_of(Butterfli::MemoryCacheAdapter)
+    end
+  end
+end

--- a/spec/butterfli/configuration/caches_spec.rb
+++ b/spec/butterfli/configuration/caches_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Caches do
+  subject { Butterfli::Configuration::Caches }
+
+  # Create fake cache to drive tests
+  let(:cache_name) { :test_cache }
+  let(:cache_config_class) do
+    stub_const 'TestCacheConfig', Class.new(Butterfli::Configuration::Cache)
+    TestCacheConfig
+  end
+  let(:cache_class) do
+    stub_const 'TestCacheAdapter', Class.new
+    TestCacheAdapter
+  end
+
+  describe "#known_caches" do
+    subject { super().known_caches }
+
+    context "when invoked with no parameters" do
+      it { expect(subject).to_not be_nil }
+    end
+  end
+
+  describe "#register_cache" do
+    subject { super().register_cache(cache_name, cache_config_class, cache_class) }
+
+    context "when invoked with a cache name and class" do
+      it do
+        expect(subject).to eq({ configuration: cache_config_class, instance: cache_class})
+        expect(Butterfli::Configuration::Caches.known_caches).to include(cache_name)
+      end
+    end
+  end
+
+  describe "#instantiate_cache" do
+    before { Butterfli::Configuration::Caches.register_cache(cache_name, cache_config_class, cache_class) }
+
+    subject { super().instantiate_cache(cache_name) }
+
+    context "when invoked with a known cache" do
+      context "(as a Symbol)" do
+        let(:cache_name) { :test_cache }
+        it { expect(subject).to be_a_kind_of(cache_config_class) }
+      end
+      context "(as a String)" do
+        let(:cache_name) { "test_cache" }
+        it { expect(subject).to be_a_kind_of(cache_config_class) }
+      end
+    end
+    context "when invoked with an unknown cache" do
+      subject { Butterfli::Configuration::Caches.instantiate_cache(:unknown_cache) }
+      it do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/butterfli/configuration/writers/syndicate_writer_spec.rb
+++ b/spec/butterfli/configuration/writers/syndicate_writer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Butterfli::Configuration::SyndicateWriter do
-  context "when configured within a processor in Butterfli" do
+  context "when configured within Butterfli" do
     let(:write_error_block) { Proc.new { } }
     before do
       Butterfli.writers = nil


### PR DESCRIPTION
Certain `Job`s inevitably need to read or write to a cache, in order to synchronize with one another.This pull request adds a simple caching layer for Butterfli components to read or write to. The backend of the cache is implemented via adapter, allowing interaction with a variety of caching implementations.

The first cache adapter added via this pull request is the `MemoryCacheAdapter`: which read/writes data to a simple hash within the application. It is intended for simple, single-machine setups.

You can enable the memory cache by adding it the the Butterfli configuration:

``` ruby
Butterfli.configure do |config|
  config.cache :memory
end
```

(It currently doesn't take any additional configuration, something that might change in the future.)

Then to use the cache:

``` ruby
Butterfli.cache
Butterfli.cache.read(key)
Butterfli.cache.write(key, value)
Butterfli.cache.fetch(key, value)
# Alternate implementation: lazy evaluates value block
Butterfli.cache.lazy_fetch key do
  value
end
Butterfli.cache.delete(key)
Butterfli.cache.clear
Butterfli.cache.has_key?(key)
Butterfli.cache.empty?
```
