### PR TITLE
Add regulation

### DIFF
--- a/lib/butterfli.rb
+++ b/lib/butterfli.rb
@@ -1,9 +1,11 @@
 require 'securerandom'
 require 'set'
+require 'time'
 
 require "butterfli/version"
 require "butterfli/configuration"
 
+require 'butterfli/regulation'
 require 'butterfli/syndication'
 require 'butterfli/data'
 require 'butterfli/writing'

--- a/lib/butterfli/configuration.rb
+++ b/lib/butterfli/configuration.rb
@@ -1,27 +1,11 @@
+module Butterfli::Configuration
+end
+
+require 'butterfli/configuration/regulation'
 require 'butterfli/configuration/provisioning'
 require 'butterfli/configuration/syndication'
 require 'butterfli/configuration/writing'
 require 'butterfli/configuration/caching'
 require 'butterfli/configuration/processing'
 
-module Butterfli
-  module Configuration
-    class Base
-      include Butterfli::Configuration::Provisioning
-      include Butterfli::Configuration::Syndication
-      include Butterfli::Configuration::Writing
-      include Butterfli::Configuration::Caching
-      include Butterfli::Configuration::Processing
-    end
-  end
-
-  def self.configuration
-    @@configuration ||= Butterfli::Configuration::Base.new
-  end
-  def self.configure(&block)
-    new_configuration = Butterfli::Configuration::Base.new
-    block.call(new_configuration)
-    @@configuration = new_configuration
-  end
-end
-  
+require 'butterfli/configuration/base'

--- a/lib/butterfli/configuration/base.rb
+++ b/lib/butterfli/configuration/base.rb
@@ -1,0 +1,21 @@
+module Butterfli
+  module Configuration
+    class Base
+      include Butterfli::Configuration::Provisioning
+      include Butterfli::Configuration::Syndication
+      include Butterfli::Configuration::Writing
+      include Butterfli::Configuration::Caching
+      include Butterfli::Configuration::Processing
+    end
+  end
+
+  def self.configuration
+    @@configuration ||= Butterfli::Configuration::Base.new
+  end
+  def self.configure(&block)
+    new_configuration = Butterfli::Configuration::Base.new
+    block.call(new_configuration)
+    @@configuration = new_configuration
+  end
+end
+  

--- a/lib/butterfli/configuration/provisioning.rb
+++ b/lib/butterfli/configuration/provisioning.rb
@@ -5,13 +5,15 @@ module Butterfli
         @providers ||= {}
 
         new_provider = Butterfli::Configuration::Provisioning::Providers.instantiate_provider(name)
-        block.call(new_provider)
+        block.call(new_provider) if !block.nil?
         @providers[name.to_sym] = new_provider
       end
-      def providers(name)
+      def providers(name = nil)
         @providers ||= {}
 
-        if @providers[name.to_sym]
+        if name.nil?
+          @providers
+        elsif @providers[name.to_sym]
           return @providers[name.to_sym]
         else
           raise "Missing provider configuration for \"#{name.to_s}\"! Did you add it to your initializer file?"

--- a/lib/butterfli/configuration/provisioning/provider.rb
+++ b/lib/butterfli/configuration/provisioning/provider.rb
@@ -1,4 +1,5 @@
 module Butterfli::Configuration::Provisioning
   class Provider
+    include Butterfli::Configuration::Regulation
   end
 end

--- a/lib/butterfli/configuration/regulation.rb
+++ b/lib/butterfli/configuration/regulation.rb
@@ -1,0 +1,15 @@
+require 'butterfli/configuration/regulation/throttle'
+require 'butterfli/configuration/regulation/throttles'
+require 'butterfli/configuration/regulation/rule_holder'
+
+require 'butterfli/configuration/regulation/policy'
+require 'butterfli/configuration/regulation/policies'
+require 'butterfli/configuration/regulation/policy_holder'
+
+module Butterfli::Configuration::Regulation
+  include Butterfli::Configuration::Regulation::PolicyHolder
+
+  def self.included(base)
+    base.class_eval { include Butterfli::Configuration::Regulation::PolicyHolder }
+  end
+end

--- a/lib/butterfli/configuration/regulation/policies.rb
+++ b/lib/butterfli/configuration/regulation/policies.rb
@@ -1,0 +1,18 @@
+module Butterfli::Configuration::Regulation
+  module Policies
+    def self.known_policies
+      @known_policies ||= {}
+    end
+    def self.register_policy(name, klass)
+      self.known_policies[name.to_sym] = klass
+    end
+    def self.instantiate_policy(name, options = {})
+      policy = self.known_policies[name.to_sym]
+      if policy
+        policy.new
+      else
+        raise "Unknown policy: #{name}!"
+      end
+    end
+  end
+end

--- a/lib/butterfli/configuration/regulation/policy.rb
+++ b/lib/butterfli/configuration/regulation/policy.rb
@@ -1,0 +1,12 @@
+module Butterfli::Configuration::Regulation
+  class Policy
+    include Butterfli::Configuration::Regulation::RuleHolder
+
+    def instantiate
+      self.instance_class.new(options)
+    end
+    def options
+      { rules: self.rules.collect { |r| r.instantiate } }
+    end
+  end
+end

--- a/lib/butterfli/configuration/regulation/policy_holder.rb
+++ b/lib/butterfli/configuration/regulation/policy_holder.rb
@@ -1,0 +1,24 @@
+module Butterfli::Configuration::Regulation
+  module PolicyHolder
+    def policies_class
+      Butterfli::Configuration::Regulation::Policies
+    end
+    def policy(name, &block)
+      @policies ||= {}
+
+      new_policy = self.policies_class.instantiate_policy(name)
+      block.call(new_policy) if !block.nil?
+      @policies[name] = new_policy
+    end
+    def policies(name = nil)
+      @policies ||= {}
+      if name.nil?
+        @policies
+      elsif @policies[name.to_sym]
+        return @policies[name.to_sym]
+      else
+        raise "Missing policy configuration for \"#{name.to_s}\"! Did you add it to your initializer file?"
+      end
+    end
+  end
+end

--- a/lib/butterfli/configuration/regulation/rule_holder.rb
+++ b/lib/butterfli/configuration/regulation/rule_holder.rb
@@ -1,0 +1,18 @@
+module Butterfli::Configuration::Regulation
+  module RuleHolder
+    def throttles_class
+      Butterfli::Configuration::Regulation::Throttles
+    end
+    def rules
+      self.throttles
+    end
+    def throttle(name, &block)
+      new_throttle = self.throttles_class.instantiate_throttle(name)
+      block.call(new_throttle) if !block.nil?
+      self.throttles << new_throttle
+    end
+    def throttles
+      @throttles ||= []
+    end
+  end
+end

--- a/lib/butterfli/configuration/regulation/throttle.rb
+++ b/lib/butterfli/configuration/regulation/throttle.rb
@@ -1,0 +1,18 @@
+module Butterfli::Configuration::Regulation
+  class Throttle
+    attr_accessor :max, :interval
+
+    def instantiate
+      self.instance_class.new(options)
+    end
+    def options
+      { max: self.max, interval: self.interval }
+    end
+    def limit(count)
+      self.max = count
+    end
+    def per_seconds(seconds)
+      self.interval = seconds
+    end
+  end
+end

--- a/lib/butterfli/configuration/regulation/throttles.rb
+++ b/lib/butterfli/configuration/regulation/throttles.rb
@@ -1,0 +1,18 @@
+module Butterfli::Configuration::Regulation
+  module Throttles
+    def self.known_throttles
+      @known_throttles ||= {}
+    end
+    def self.register_throttle(name, klass)
+      self.known_throttles[name.to_sym] = klass
+    end
+    def self.instantiate_throttle(name, options = {})
+      throttle = self.known_throttles[name.to_sym]
+      if throttle
+        throttle.new
+      else
+        raise "Unknown throttle: #{name}!"
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation.rb
+++ b/lib/butterfli/regulation.rb
@@ -1,0 +1,11 @@
+require 'butterfli/regulation/rule'
+require 'butterfli/regulation/conditions'
+require 'butterfli/regulation/matchers'
+require 'butterfli/regulation/throttle'
+require 'butterfli/regulation/rule_holder'
+
+require 'butterfli/regulation/policy_holder'
+require 'butterfli/regulation/policy'
+
+module Butterfli::Regulation
+end

--- a/lib/butterfli/regulation/conditions.rb
+++ b/lib/butterfli/regulation/conditions.rb
@@ -1,0 +1,1 @@
+require 'butterfli/regulation/conditions/rate'

--- a/lib/butterfli/regulation/conditions/rate.rb
+++ b/lib/butterfli/regulation/conditions/rate.rb
@@ -1,0 +1,29 @@
+module Butterfli::Regulation::Conditions
+  module Rate
+    attr_accessor :max, :interval
+
+    def effective_rate
+      if self.max && self.interval
+        self.max.to_f / self.interval.to_f
+      end
+    end
+    def seconds_per
+      if self.max && self.interval
+        self.interval.to_f / self.max.to_f
+      end
+    end
+    def self.included(base)
+      base.class_eval do
+        include Butterfli::Regulation::Rule
+
+        permits_if do |rule, item|
+          if rule.effective_rate && last_time = rule.fact(:last_time).from(rule, item)
+            (Time.now-last_time) > rule.seconds_per
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/matchers.rb
+++ b/lib/butterfli/regulation/matchers.rb
@@ -1,0 +1,1 @@
+require 'butterfli/regulation/matchers/type'

--- a/lib/butterfli/regulation/matchers/type.rb
+++ b/lib/butterfli/regulation/matchers/type.rb
@@ -1,0 +1,16 @@
+module Butterfli::Regulation::Matchers
+  module Type
+    attr_accessor :type
+
+    def self.included(base)
+      base.class_eval do
+        include Butterfli::Regulation::Rule
+
+        applies_if do |rule, item|
+          # Must explicitly be of the type, otherwise rule doesn't apply
+          !rule.type.nil? && item.class <= rule.type
+        end
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/policy.rb
+++ b/lib/butterfli/regulation/policy.rb
@@ -1,0 +1,8 @@
+module Butterfli::Regulation
+  class Policy
+    include Butterfli::Regulation::RuleHolder
+    def initialize(options = {})
+      self.rules = options[:rules]
+    end
+  end
+end

--- a/lib/butterfli/regulation/policy_holder.rb
+++ b/lib/butterfli/regulation/policy_holder.rb
@@ -1,0 +1,13 @@
+module Butterfli::Regulation
+  module PolicyHolder
+    def policies=(policies)
+      @policies = policies
+    end
+    def policies
+      (@policies ||= {})
+    end
+    def add_policy(name, policy)
+      self.policies[name] = policy
+    end
+  end
+end

--- a/lib/butterfli/regulation/rule.rb
+++ b/lib/butterfli/regulation/rule.rb
@@ -1,0 +1,68 @@
+require 'butterfli/regulation/rule/matcher'
+require 'butterfli/regulation/rule/condition'
+require 'butterfli/regulation/rule/fact'
+
+module Butterfli::Regulation
+  module Rule
+    def applies_to?(item)
+      if !self.class.matchers.empty?
+        applies = self.class.matchers.inject(true) do |applies, matcher|
+          applies && (matcher.call(self, item) == true)
+        end
+      else
+        false
+      end
+    end
+    def permits?(item)
+      permitted = self.class.conditions.inject(true) do |permitted, condition|
+        permitted && (condition.call(self, item) == true)
+      end
+    end
+    def fact(name)
+      if self.class.facts.has_key?(name)
+        self.class.facts[name]
+      else
+        raise KeyError, "#{self.class.name} does not define fact '#{name}'!"
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+    module ClassMethods
+      def applies_if(&block)
+        (@matchers ||= Set.new) << Butterfli::Regulation::Rule::Matcher.new(&block)
+      end
+      def matchers
+        m = (@matchers ||= Set.new).dup
+        if self.superclass.respond_to?(:matchers)
+          self.superclass.matchers.merge(m)
+        else
+          m
+        end
+      end
+      def permits_if(&block)
+        (@conditions ||= Set.new) << Butterfli::Regulation::Rule::Condition.new(&block)
+      end
+      def conditions
+        c = (@conditions ||= Set.new).dup
+        if self.superclass.respond_to?(:conditions)
+          self.superclass.conditions.merge(c)
+        else
+          c
+        end
+      end
+      def fact(name, &block)
+        (@facts ||= {})[name] = Butterfli::Regulation::Rule::Fact.new(&block)
+      end
+      def facts
+        f = (@facts ||= {})
+        if self.superclass.respond_to?(:facts)
+          self.superclass.facts.merge(f)
+        else
+          f.dup
+        end
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/rule/condition.rb
+++ b/lib/butterfli/regulation/rule/condition.rb
@@ -1,0 +1,13 @@
+module Butterfli::Regulation
+  module Rule
+    class Condition
+      attr_accessor :block
+      def initialize(&block)
+        self.block = block
+      end
+      def call(*args)
+        self.block.call(*args)
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/rule/fact.rb
+++ b/lib/butterfli/regulation/rule/fact.rb
@@ -1,0 +1,16 @@
+module Butterfli::Regulation
+  module Rule
+    class Fact
+      attr_accessor :block
+      def initialize(&block)
+        self.block = block
+      end
+      def from(*args)
+        self.block.call(*args)
+      end
+      def read
+        self.block.call
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/rule/matcher.rb
+++ b/lib/butterfli/regulation/rule/matcher.rb
@@ -1,0 +1,13 @@
+module Butterfli::Regulation
+  module Rule
+    class Matcher
+      attr_accessor :block
+      def initialize(&block)
+        self.block = block
+      end
+      def call(*args)
+        self.block.call(*args)
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/rule_holder.rb
+++ b/lib/butterfli/regulation/rule_holder.rb
@@ -1,0 +1,18 @@
+module Butterfli::Regulation
+  module RuleHolder
+    def rules=(rules)
+      @rules = rules
+    end
+    def rules
+      (@rules ||= Set.new)
+    end
+    def add_rules(*rules)
+      self.rules.merge(rules.flatten)
+    end
+    def permits?(item)
+      permitted = self.rules.inject(true) do |permitted, rule|
+        permitted && (!rule.applies_to?(item) || rule.permits?(item))
+      end
+    end
+  end
+end

--- a/lib/butterfli/regulation/throttle.rb
+++ b/lib/butterfli/regulation/throttle.rb
@@ -1,0 +1,11 @@
+module Butterfli::Regulation
+  class Throttle
+    include Butterfli::Regulation::Rule
+    include Butterfli::Regulation::Conditions::Rate
+
+    def initialize(options = {})
+      self.max = options[:max]
+      self.interval = options[:interval]
+    end
+  end
+end

--- a/spec/butterfli/configuration/caching_spec.rb
+++ b/spec/butterfli/configuration/caching_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Caching do
+  # TODO: Fill this out with more detail
+  it { expect(Butterfli::Configuration::Caching).to_not be_nil }
+end

--- a/spec/butterfli/configuration/processing_spec.rb
+++ b/spec/butterfli/configuration/processing_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Processing do
+  # TODO: Fill this out with more detail
+  it { expect(Butterfli::Configuration::Processing).to_not be_nil }
+end

--- a/spec/butterfli/configuration/provisioning/provider_spec.rb
+++ b/spec/butterfli/configuration/provisioning/provider_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 
 describe Butterfli::Configuration::Provisioning::Provider do
   # TODO: Fill this out with more detail
-  it { expect(Butterfli::Configuration::Provisioning::Provider).to_not be_nil }
+  it { expect(Butterfli::Configuration::Provisioning::Provider <= Butterfli::Configuration::Regulation).to be true }
 end

--- a/spec/butterfli/configuration/provisioning_spec.rb
+++ b/spec/butterfli/configuration/provisioning_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Provisioning do
+  # TODO: Fill this out with more detail
+  it { expect(Butterfli::Configuration::Provisioning).to_not be_nil }
+end

--- a/spec/butterfli/configuration/regulation/policies_spec.rb
+++ b/spec/butterfli/configuration/regulation/policies_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::Policies do
+  subject { Butterfli::Configuration::Regulation::Policies }
+
+  describe "#known_policies" do
+    subject { super().known_policies }
+
+    context "when invoked with no parameters" do
+      it { expect(subject).to_not be_nil }
+    end
+  end
+
+  describe "#register_policy" do
+    subject { super().register_policy(policy_name, policy_class) }
+
+    # Create fake policy to drive tests
+    let(:policy_name) { :test_policy }
+    let(:policy_class) do
+      stub_const 'TestPolicy', Class.new(Butterfli::Configuration::Regulation::Policy)
+      TestPolicy
+    end
+
+    context "when invoked with a policy name and class" do
+      it do
+        expect(subject).to eq(policy_class)
+        expect(Butterfli::Configuration::Regulation::Policies.known_policies).to include(policy_name)
+      end
+    end
+  end
+
+  describe "#instantiate_policy" do
+    subject { super().instantiate_policy(policy_name) }
+
+    # Create fake policy to drive tests
+    let(:policy_class) do
+      stub_const 'TestPolicy', Class.new(Butterfli::Configuration::Regulation::Policy)
+      TestPolicy
+    end
+    before { Butterfli::Configuration::Regulation::Policies.register_policy(:test_policy, policy_class) }
+
+    context "when invoked with a known policy" do
+      context "(as a Symbol)" do
+        let(:policy_name) { :test_policy }
+        it { expect(subject).to be_a_kind_of(policy_class) }
+      end
+      context "(as a String)" do
+        let(:policy_name) { "test_policy" }
+        it { expect(subject).to be_a_kind_of(policy_class) }
+      end
+    end
+    context "when invoked with an unknown policy" do
+      let(:policy_name) { :unknown_policy }
+      it do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/butterfli/configuration/regulation/policy_holder_spec.rb
+++ b/spec/butterfli/configuration/regulation/policy_holder_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::PolicyHolder do
+  let(:policy_holder_class) do
+    stub_const 'ProviderConfig', Class.new
+    ProviderConfig.class_eval { include Butterfli::Configuration::Regulation::PolicyHolder }
+    ProviderConfig
+  end
+  let(:policy_holder) { policy_holder_class.new }
+
+  describe "#policies" do
+    subject { policy_holder.policies }
+    context "when no policies have been added" do
+      it { expect(subject).to be_empty }
+    end
+    context "when policies have been added" do
+      let(:policy) { double('policy') }
+      let(:policy_name) { :policy }
+      before(:each) { policy_holder.policies[policy_name] = policy }
+      it { expect(subject).to include(policy_name) }
+    end
+  end
+  describe "#policy" do
+    context "when given a name and block" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { |t| target.configure(t) } }
+      let(:name) { :test }
+      let(:policy_class) { double('policy_class') }
+      let(:policy_object) { double('policy_object') }
+
+      before(:each) do
+        allow(policy_class).to receive(:new).and_return(policy_object)
+        Butterfli::Configuration::Regulation::Policies.register_policy(name, policy_class)
+      end
+      after(:each) { Butterfli::Configuration::Regulation::Policies.known_policies.clear }
+
+      subject { policy_holder.policy name, &block }
+
+      it do
+        expect(target).to receive(:configure).with(policy_object)
+        subject
+        expect(policy_holder.policies).to include(name)
+      end
+    end
+  end
+  describe "#policies" do
+    subject { policy_holder.policies }
+    context "when no policies have been added" do
+      it { expect(subject).to be_empty }
+    end
+  end
+end

--- a/spec/butterfli/configuration/regulation/policy_spec.rb
+++ b/spec/butterfli/configuration/regulation/policy_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::Policy do
+  it { expect(Butterfli::Configuration::Regulation::Policy <= Butterfli::Configuration::Regulation::RuleHolder).to be true }
+end

--- a/spec/butterfli/configuration/regulation/rule_holder_spec.rb
+++ b/spec/butterfli/configuration/regulation/rule_holder_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::RuleHolder do
+  let(:regulated_class) do
+    stub_const 'ProviderConfig', Class.new
+    ProviderConfig.class_eval { include Butterfli::Configuration::Regulation::RuleHolder }
+    ProviderConfig
+  end
+  let(:regulated_object) { regulated_class.new }
+
+  describe "#rules" do
+    subject { regulated_object.rules }
+    context "when no rules have been added" do
+      it { expect(subject).to be_empty }
+    end
+    context "when rules have been added" do
+      let(:throttle) { double('throttle') }
+      before(:each) { regulated_object.throttles << throttle }
+      it { expect(subject).to include(throttle) }
+    end
+  end
+  describe "#throttle" do
+    context "when given a name and block" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { |t| target.configure(t) } }
+      let(:name) { :test }
+      let(:throttle_class) { double('throttle_class') }
+      let(:throttle_object) { double('throttle_object') }
+
+      before(:each) do
+        allow(throttle_class).to receive(:new).and_return(throttle_object)
+        Butterfli::Configuration::Regulation::Throttles.register_throttle(name, throttle_class)
+      end
+      after(:each) { Butterfli::Configuration::Regulation::Throttles.known_throttles.clear }
+
+      subject { regulated_object.throttle name, &block }
+
+      it do
+        expect(target).to receive(:configure).with(throttle_object)
+        subject
+        expect(regulated_object.throttles).to include(throttle_object)
+      end
+    end
+  end
+  describe "#throttles" do
+    subject { regulated_object.throttles }
+    context "when no throttles have been added" do
+      it { expect(subject).to be_empty }
+    end
+  end
+end

--- a/spec/butterfli/configuration/regulation/throttle_spec.rb
+++ b/spec/butterfli/configuration/regulation/throttle_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::Throttle do
+  let(:throttle) { Butterfli::Configuration::Regulation::Throttle.new }
+  subject { throttle }
+
+  context "#limit" do
+    it { expect(throttle).to respond_to(:limit) }
+    it { expect(throttle).to respond_to(:max) }
+    context "when given a block" do
+      let(:limit) { 100 }
+      subject { throttle.limit limit }
+      it { subject; expect(throttle.max).to eq(limit) }
+    end
+  end
+  context "#per_seconds" do
+    it { expect(throttle).to respond_to(:per_seconds) }
+    it { expect(throttle).to respond_to(:interval) }
+    context "when given a block" do
+      let(:seconds) { 100 }
+      subject { throttle.per_seconds seconds }
+      it { subject; expect(throttle.interval).to eq(seconds) }
+    end
+  end
+end

--- a/spec/butterfli/configuration/regulation/throttles_spec.rb
+++ b/spec/butterfli/configuration/regulation/throttles_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation::Throttles do
+  subject { Butterfli::Configuration::Regulation::Throttles }
+
+  describe "#known_throttles" do
+    subject { super().known_throttles }
+
+    context "when invoked with no parameters" do
+      it { expect(subject).to_not be_nil }
+    end
+  end
+
+  describe "#register_throttle" do
+    subject { super().register_throttle(throttle_name, throttle_class) }
+
+    # Create fake throttle to drive tests
+    let(:throttle_name) { :test_throttle }
+    let(:throttle_class) do
+      stub_const 'TestThrottle', Class.new(Butterfli::Configuration::Regulation::Throttle)
+      TestThrottle
+    end
+
+    context "when invoked with a throttle name and class" do
+      it do
+        expect(subject).to eq(throttle_class)
+        expect(Butterfli::Configuration::Regulation::Throttles.known_throttles).to include(throttle_name)
+      end
+    end
+  end
+
+  describe "#instantiate_throttle" do
+    subject { super().instantiate_throttle(throttle_name) }
+
+    # Create fake throttle to drive tests
+    let(:throttle_class) do
+      stub_const 'TestThrottle', Class.new(Butterfli::Configuration::Regulation::Throttle)
+      TestThrottle
+    end
+    before { Butterfli::Configuration::Regulation::Throttles.register_throttle(:test_throttle, throttle_class) }
+
+    context "when invoked with a known throttle" do
+      context "(as a Symbol)" do
+        let(:throttle_name) { :test_throttle }
+        it { expect(subject).to be_a_kind_of(throttle_class) }
+      end
+      context "(as a String)" do
+        let(:throttle_name) { "test_throttle" }
+        it { expect(subject).to be_a_kind_of(throttle_class) }
+      end
+    end
+    context "when invoked with an unknown throttle" do
+      let(:throttle_name) { :unknown_throttle }
+      it do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/butterfli/configuration/regulation_spec.rb
+++ b/spec/butterfli/configuration/regulation_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Regulation do
+  it { expect(Butterfli::Configuration::Regulation <= Butterfli::Configuration::Regulation::PolicyHolder).to be true }
+end

--- a/spec/butterfli/configuration/writing_spec.rb
+++ b/spec/butterfli/configuration/writing_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Butterfli::Configuration::Writing do
+  # TODO: Fill this out with more detail
+  it { expect(Butterfli::Configuration::Writing).to_not be_nil }
+end

--- a/spec/butterfli/processing/worker_spec.rb
+++ b/spec/butterfli/processing/worker_spec.rb
@@ -283,7 +283,7 @@ describe Butterfli::Processing::Worker do
     context "for the second time" do
       context "after the worker has been stopped" do
         let(:work_block) { Proc.new { sleep(0.01) } }
-        before(:each) { worker.start; sleep(0.01); worker.stop; sleep(0.01) }
+        before(:each) { worker.start; sleep(0.01); worker.stop; sleep(0.02) }
         it do
           expect(subject).to be true
           expect(worker.alive?).to be true

--- a/spec/butterfli/regulation/conditions/rate_spec.rb
+++ b/spec/butterfli/regulation/conditions/rate_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Conditions::Rate do
+  let(:rule_class) do
+    stub_const 'TestRule', Class.new
+    TestRule.class_eval { include Butterfli::Regulation::Conditions::Rate }
+    TestRule
+  end
+  # Always force rule to apply, to test condition
+  before(:each) { rule_class.applies_if(&(Proc.new { true })) }
+  let(:rule) { rule_class.new }
+
+  describe "#max" do
+    it { expect(rule).to respond_to(:max) }
+    it { expect(rule).to respond_to(:max=) }
+  end
+  describe "#interval" do
+    it { expect(rule).to respond_to(:interval) }
+    it { expect(rule).to respond_to(:interval=) }
+  end
+  describe "#effective_rate" do
+    subject { rule.effective_rate }
+    before do
+      rule.max = max
+      rule.interval = interval
+    end
+    let(:max) { 400 }
+    let(:interval) { 60 }
+    it { expect(subject).to eq(max.to_f/interval.to_f) }
+  end
+  describe "#seconds_per" do
+    subject { rule.seconds_per }
+    before do
+      rule.max = max
+      rule.interval = interval
+    end
+    let(:max) { 60 }
+    let(:interval) { 400 }
+    it { expect(subject).to eq(interval.to_f/max.to_f) }
+  end
+  describe "#permits?" do
+    subject { rule.permits?(item) }
+    let(:target) { double('target') }
+    let(:item) { 1 }
+    before(:each) do
+      rule.max = max
+      rule.interval = interval
+      rule.class.fact :last_time do |rule, item|
+        target.last_time(rule, item)
+      end
+      allow(target).to receive(:last_time).with(Butterfli::Regulation::Rule, Object).and_return(last_time)
+    end
+    context "when the rate has not been exceeded" do
+      let(:last_time) { Time.now - 120 }
+      let(:max) { 1 }
+      let(:interval) { 60 }
+      it do
+        expect(target).to receive(:last_time).with(rule, item)
+        expect(subject).to be true
+      end
+    end
+    context "when the rate has been exceeded" do
+      let(:last_time) { Time.now - 30 }
+      let(:max) { 1 }
+      let(:interval) { 60 }
+      it do
+        expect(target).to receive(:last_time).with(rule, item)
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/spec/butterfli/regulation/conditions_spec.rb
+++ b/spec/butterfli/regulation/conditions_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli do
+  # Conditions doesn't define any behavior
+end

--- a/spec/butterfli/regulation/matchers/type_spec.rb
+++ b/spec/butterfli/regulation/matchers/type_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Matchers::Type do
+  let(:rule_class) do
+    stub_const 'TestRule', Class.new
+    TestRule.class_eval { include Butterfli::Regulation::Matchers::Type }
+    TestRule
+  end
+  let(:rule) { rule_class.new }
+
+  describe "#type" do
+    it { expect(rule).to respond_to(:type) }
+    it { expect(rule).to respond_to(:type=) }
+  end
+  describe "#applies_to?" do
+    subject { rule.applies_to?(item) }
+    let(:item) { 1 }
+    before(:each) { rule.type = type }
+    context "when the item is of type" do
+      let(:type) { Fixnum }
+      it { expect(subject).to be true }
+    end
+    context "when the item is of descendant type" do
+      let(:type) { Integer }
+      it { expect(subject).to be true }
+    end
+    context "when the item is not of type" do
+      let(:type) { String }
+      it { expect(subject).to be false }
+    end
+  end
+end

--- a/spec/butterfli/regulation/matchers_spec.rb
+++ b/spec/butterfli/regulation/matchers_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli do
+  # Matchers doesn't define any behavior
+end

--- a/spec/butterfli/regulation/policy_holder_spec.rb
+++ b/spec/butterfli/regulation/policy_holder_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::PolicyHolder do
+  let(:policy_holder_class) do
+    stub_const 'PolicyHolderClass', Class.new
+    PolicyHolderClass.class_eval { include Butterfli::Regulation::PolicyHolder }
+    PolicyHolderClass
+  end
+  let(:policy_holder) { policy_holder_class.new }
+
+  describe "#policies" do
+    subject { policy_holder.policies }
+    context "when no policies have been added" do
+      it { expect(subject).to be_empty }
+    end
+    context "when a policy has been added" do
+      let(:policy_name) { :policy_one }
+      let(:policy) { double('policy') }
+      before(:each) { policy_holder.add_policy(policy_name, policy) }
+      it { expect(subject).to include(policy_name) }
+    end
+  end
+end

--- a/spec/butterfli/regulation/policy_spec.rb
+++ b/spec/butterfli/regulation/policy_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Policy do
+  it { expect(Butterfli::Regulation::Policy <= Butterfli::Regulation::RuleHolder).to be true }
+end

--- a/spec/butterfli/regulation/rule/condition_spec.rb
+++ b/spec/butterfli/regulation/rule/condition_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Rule::Condition do
+  let(:condition) { Butterfli::Regulation::Rule::Condition.new(&block) }
+  describe "when instantiated" do
+    subject { condition }
+    context "with a block" do
+      let(:block) { Proc.new { } }
+      it { expect(subject.block).to eq(block) }
+    end
+  end
+  describe "#call" do
+    context "when given arguments" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { |one, two| target.called(one, two) } }
+      let(:args) { [1, 2] }
+      subject { condition.call(*args) }
+      it { expect(target).to receive(:called).with(*args); subject }
+    end
+  end
+end

--- a/spec/butterfli/regulation/rule/fact_spec.rb
+++ b/spec/butterfli/regulation/rule/fact_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Rule::Fact do
+  let(:fact) { Butterfli::Regulation::Rule::Fact.new(&block) }
+  describe "when instantiated" do
+    subject { fact }
+    context "with a block" do
+      let(:block) { Proc.new { } }
+      it { expect(subject.block).to eq(block) }
+    end
+  end
+  describe "#from" do
+    context "when given arguments" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { |one, two| target.called(one, two) } }
+      let(:args) { [1, 2] }
+      subject { fact.from(*args) }
+      it { expect(target).to receive(:called).with(*args); subject }
+    end
+  end
+  describe "#read" do
+    context "when given arguments" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { target.called } }
+      subject { fact.read }
+      it { expect(target).to receive(:called); subject }
+    end
+  end
+end

--- a/spec/butterfli/regulation/rule/matcher_spec.rb
+++ b/spec/butterfli/regulation/rule/matcher_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Rule::Matcher do
+  let(:matcher) { Butterfli::Regulation::Rule::Matcher.new(&block) }
+  describe "when instantiated" do
+    subject { matcher }
+    context "with a block" do
+      let(:block) { Proc.new { } }
+      it { expect(subject.block).to eq(block) }
+    end
+  end
+  describe "#call" do
+    context "when given arguments" do
+      let(:target) { double('target') }
+      let(:block) { Proc.new { |one, two| target.called(one, two) } }
+      let(:args) { [1, 2] }
+      subject { matcher.call(*args) }
+      it { expect(target).to receive(:called).with(*args); subject }
+    end
+  end
+end

--- a/spec/butterfli/regulation/rule_holder_spec.rb
+++ b/spec/butterfli/regulation/rule_holder_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::RuleHolder do
+  let(:rule_holder_class) do
+    stub_const 'RuleHolderClass', Class.new
+    RuleHolderClass.class_eval { include Butterfli::Regulation::RuleHolder }
+    RuleHolderClass
+  end
+  let(:rule_holder) { rule_holder_class.new }
+  let(:rule_class) do
+    stub_const 'TestRule', Class.new
+    TestRule.class_eval { include Butterfli::Regulation::Rule }
+    TestRule
+  end
+
+  describe "#rules" do
+    subject { rule_holder.rules }
+    context "when no rules have been added" do
+      it { expect(subject).to be_empty }
+    end
+    context "when a rule has been added" do
+      let(:rule) { double('rule') }
+      before(:each) { rule_holder.add_rules(rule) }
+      it { expect(subject).to include(rule) }
+    end
+  end
+
+  describe "#permits?" do
+    subject { rule_holder.permits?(item) }
+    let(:item) { 1 }
+    context "when there are no rules" do
+      it { expect(subject).to be true }
+    end
+    context "when a rule is defined" do
+      let(:rule) { rule_class.new }
+      before(:each) { rule_holder.add_rules(rule) }
+      context "that doesn't apply" do
+        before(:each) do
+          rule.class.applies_if { false }
+          rule.class.permits_if { item != item }
+        end
+        it { expect(subject).to be true }
+      end
+      context "that applies" do
+        before(:each) { rule.class.applies_if { true } }
+        context "but whose conditions don't match" do
+          before(:each) { rule.class.permits_if { false } }
+          it { expect(subject).to be false }
+        end
+        context "and whose conditions match" do
+          before(:each) { rule.class.permits_if { true } }
+          it { expect(subject).to be true }
+        end
+      end
+    end
+    context "when multiple rules exist" do
+      let(:rule) { rule_class.new }
+      let(:rule_two_class) do
+        stub_const 'TestRuleTwo', Class.new
+        TestRuleTwo.class_eval { include Butterfli::Regulation::Rule }
+        TestRuleTwo
+      end
+      let(:rule_two) { rule_two_class.new }
+      before(:each) { rule_holder.add_rules(rule, rule_two) }
+      context "of which all apply" do
+        before(:each) do
+          [rule.class, rule_two.class].each { |c| c.applies_if { true } }
+        end
+        context "but only one doesn't match" do
+          before(:each) { rule_two.class.permits_if { false } }
+          it { expect(subject).to be false }
+        end
+      end
+    end
+  end
+end

--- a/spec/butterfli/regulation/rule_spec.rb
+++ b/spec/butterfli/regulation/rule_spec.rb
@@ -1,0 +1,206 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Rule do
+  let(:rule_class) do
+    stub_const 'TestRule', Class.new
+    TestRule.class_eval { include Butterfli::Regulation::Rule }
+    TestRule
+  end
+  describe "class method" do
+    describe "#applies_if" do
+      subject { rule_class.applies_if &block }
+      context "when given a block" do
+        let(:block) { Proc.new { } }
+        it { subject; expect(rule_class.matchers.first.block).to eq(block) }
+      end
+    end
+    describe "#matchers" do
+      subject { rule_class.matchers }
+      context "when no matchers have been added" do
+        it { expect(subject).to be_empty }
+      end
+      context "when a matcher has been added" do
+        let(:block) { Proc.new { } }
+        before(:each) { rule_class.applies_if &block }
+        it { expect(subject).to have_exactly(1).items }
+        it { expect(subject.first).to be_a_kind_of(Butterfli::Regulation::Rule::Matcher) }
+      end
+    end
+    describe "#permits_if" do
+      subject { rule_class.permits_if &block }
+      context "when given a block" do
+        let(:block) { Proc.new { } }
+        it { subject; expect(rule_class.conditions.first.block).to eq(block) }
+      end
+    end
+    describe "#conditions" do
+      subject { rule_class.conditions }
+      context "when no conditions have been added" do
+        it { expect(subject).to be_empty }
+      end
+      context "when a condition has been added" do
+        let(:block) { Proc.new { } }
+        before(:each) { rule_class.permits_if &block }
+        it { expect(subject).to have_exactly(1).items }
+        it { expect(subject.first).to be_a_kind_of(Butterfli::Regulation::Rule::Condition) }
+      end
+    end
+    describe "#fact" do
+      subject { rule_class.fact name, &block }
+      context "when given a name and a block" do
+        let(:name) { :fact }
+        let(:block) { Proc.new { } }
+        it { subject; expect(rule_class.facts[name].block).to eq(block) }
+      end
+    end
+    describe "#facts" do
+      subject { rule_class.facts }
+      context "when no facts have been added" do
+        it { expect(subject).to be_empty }
+      end
+      context "when a fact has been added" do
+        let(:name) { :fact }
+        let(:block) { Proc.new { } }
+        before(:each) { rule_class.fact name, &block }
+        it { expect(subject).to have_exactly(1).items }
+        it { expect(subject[name]).to be_a_kind_of(Butterfli::Regulation::Rule::Fact) }
+      end
+    end
+  end
+
+  describe "instance method" do
+    let(:rule) { rule_class.new }
+    describe "#applies_to?" do
+      let(:item) { 1 }
+      subject { rule.applies_to?(item) }
+      context "when no matchers have been defined" do
+        it { expect(subject).to be false }
+      end
+      context "when a matcher" do
+        before(:each) { rule.class.applies_if(&matcher) }
+        context "that matches the item is defined" do
+          let(:matcher) { Proc.new { item == item } }
+          it { expect(subject).to be true }
+          context "and another that matches is defined" do
+            let(:matcher_two) { Proc.new { item == item } }
+            before(:each) { rule.class.applies_if(&matcher_two) }
+            it { expect(subject).to be true }
+          end
+          context "and another that doesn't match is defined" do
+            let(:matcher_two) { Proc.new { item != item } }
+            before(:each) { rule.class.applies_if(&matcher_two) }
+            it { expect(subject).to be false }
+          end
+        end
+        context "that doesn't match the item is defined" do
+          let(:matcher) { Proc.new { item != item } }
+          it { expect(subject).to be false }
+          context "and another that doesn't match is defined" do
+            let(:matcher_two) { Proc.new { item != item } }
+            before(:each) { rule.class.applies_if(&matcher_two) }
+            it { expect(subject).to be false }
+          end
+        end
+      end
+    end
+    describe "#permits?" do
+      let(:item) { 1 }
+      subject { rule.permits?(item) }
+
+      context "when the rule applies" do
+        before(:each) { rule.class.applies_if(&(Proc.new { true })) }
+        context "when no conditions have been defined" do
+          it { expect(subject).to be true }
+        end
+        context "and a condition" do
+          before(:each) { rule.class.permits_if(&condition) }
+          context "that matches the item is defined" do
+            let(:condition) { Proc.new { item == item } }
+            it { expect(subject).to be true }
+            context "and another that matches is defined" do
+              let(:condition_two) { Proc.new { item == item } }
+              before(:each) { rule.class.permits_if(&condition_two) }
+              it { expect(subject).to be true }
+            end
+            context "and another that doesn't match is defined" do
+              let(:condition_two) { Proc.new { item != item } }
+              before(:each) { rule.class.permits_if(&condition_two) }
+              it { expect(subject).to be false }
+            end
+          end
+          context "that doesn't match the item is defined" do
+            let(:condition) { Proc.new { item != item } }
+            it { expect(subject).to be false }
+            context "and another that doesn't match is defined" do
+              let(:condition_two) { Proc.new { item != item } }
+              before(:each) { rule.class.permits_if(&condition_two) }
+              it { expect(subject).to be false }
+            end
+          end
+        end
+      end
+      context "when the rule doesn't apply" do
+        before(:each) { rule.class.applies_if(&(Proc.new { false })) }
+        context "when no conditions have been defined" do
+          # True because #permits? doesn't care whether rule applies
+          it { expect(subject).to be true }
+        end
+        context "and a condition" do
+          before(:each) { rule.class.permits_if(&condition) }
+          context "that matches the item is defined" do
+            let(:condition) { Proc.new { item == item } }
+            # True because #permits? doesn't care whether rule applies
+            it { expect(subject).to be true }
+          end
+        end
+      end
+    end
+    describe "#fact" do
+      subject { rule.fact(name) }
+      context "when given a name" do
+        let(:name) { :fact }
+        context "of a defined fact" do
+          before(:each) { rule.class.fact(name, &(Proc.new { name })) }
+          it { expect(subject).to be_a_kind_of(Butterfli::Regulation::Rule::Fact) }
+        end
+        context "of an undefined fact" do
+          it { expect { subject }.to raise_error(KeyError) }
+        end
+      end
+    end
+  end
+
+  context "when inherited by a class with matchers/conditions/facts" do
+    let(:fact_name) { :fact }
+    before(:each) do
+      rule_class.applies_if(&(Proc.new { true }))
+      rule_class.permits_if(&(Proc.new { true }))
+      rule_class.fact(fact_name, &(Proc.new { true }))
+    end
+    subject { rule_class }
+    it { expect(subject.matchers).to have_exactly(1).items }
+    it { expect(subject.conditions).to have_exactly(1).items }
+    it { expect(subject.facts).to have_exactly(1).items }
+
+    context "whom is then inherited by another class" do
+      let(:grandchild_class) do
+        stub_const 'GranchildRule', Class.new(rule_class)
+        GranchildRule
+      end
+      subject { grandchild_class }
+      context "that defines a matcher" do
+        before(:each) { grandchild_class.applies_if(&(Proc.new { true })) }
+        it { expect(subject.matchers).to have_exactly(2).items }
+      end
+      context "that defines a condition" do
+        before(:each) { grandchild_class.permits_if(&(Proc.new { true })) }
+        it { expect(subject.conditions).to have_exactly(2).items }
+      end
+      context "that defines a fact" do
+        let(:grandchild_fact_name) { :grandchild_fact }
+        before(:each) { grandchild_class.fact(grandchild_fact_name, &(Proc.new { true })) }
+        it { expect(subject.facts).to have_exactly(2).items }
+      end
+    end
+  end
+end

--- a/spec/butterfli/regulation/throttle_spec.rb
+++ b/spec/butterfli/regulation/throttle_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Butterfli::Regulation::Throttle do
+  it { expect(Butterfli::Regulation::Throttle <= Butterfli::Regulation::Rule).to be true }
+  it { expect(Butterfli::Regulation::Throttle <= Butterfli::Regulation::Conditions::Rate).to be true }
+  context "when initialized" do
+    context "with a max" do
+      subject { Butterfli::Regulation::Throttle.new(max: max) }
+      let(:max) { 1 }
+      it { expect(subject.max).to eq(max) }
+    end
+    context "with an interval" do
+      subject { Butterfli::Regulation::Throttle.new(interval: interval) }
+      let(:interval) { 60 }
+      it { expect(subject.interval).to eq(interval) }
+    end
+  end
+end

--- a/spec/butterfli/regulation_spec.rb
+++ b/spec/butterfli/regulation_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli do
+  # Regulation doesn't define any behavior
+end


### PR DESCRIPTION
Some of the data sources that Butterfli pulls from presents challenges with API limits. In certain cases, a large number callbacks from a provider (e.g. Instagram) may result in a quantity of API requests that might actually exceed limits, resulting it API client termination.

This pull request introduces _regulation_: a basic rule framework which things can be tested against to determine whether it's permitted or not. Regulation consist of 2 major pieces: a policy and a set of rules. A policy is simply a collection of rules. An item can be tested against a policy to see whether it violates the rules therein.
##### Explanation of how policies and rules work

Rules themselves are comprised of two checks: `applies_to?` and `permits?`.

`applies_to?` checks whether a rule should be applied to the object in question (e.g. "Is this object a car? If so, apply this traffic rule.") This check is what's referred to in the code as a _matcher_. A rule can have one or more matchers. If all matchers return true, then `applies_to?` evaluates to true. If there are no matchers specified, the return value is false.

The next step `permits?` then actually runs another collection of checks, each which are called a _condition_. If all conditions return true, or there are no conditions, then `permits?` returns true. If at least one condition returns false, then `permits?` returns false.

When checking whether a policy permits an object, all rules in the policy must either permit the object, or not apply. If at least one rule applies which doesn't permit the object, `permits?` returns false. If there are no rules in the policy, `permits?` always returns true.
#### Rule facts

Some rules require additional information to evaluate themselves. Rules in addition to matchers and conditions also contain _facts_: a simple block that returns a value. This allows rules to organize information a bit more clearly, or to defer the definition of a fact to an inheriting rule.
#### Defining a rule

For those who are extending the `Butterfli` framework, custom rules can be defined. A sample rule is as follows:

``` ruby
class SpeedLimitRule
    include Butterfli::Regulation::Rule
    # This matcher determines whether it applies to an object
    applies_if do |rule, item|
      item.class == Car
    end
    # This fact returns a value that helps evaluate the rule
    fact :speed do |item|
      item.distance_traveled / item.time_traveled
    end
    # This condition determines whether the rule permits the object
    permits_if do |rule, item|
      rule.fact(:speed).from(item) <= 60
    end
end
```
#### Classes a part of the regulation framework

``` ruby
Butterfli::Regulation::PolicyHolder # Module for any class that holds a collection of policies
Butterfli::Regulation::Policy # Base class for policies
Butterfli::Regulation::RuleHolder # Module for any class that holds a collection of rules (e.g. Policy)
Butterfli::Regulation::Rule # Module all rules include
Butterfli::Regulation::Rule::Matcher # A rule matcher
Butterfli::Regulation::Rule::Condition # A rule condition
Butterfli::Regulation::Rule::Fact # A rule fact

# Some implementation classes
Butterfli::Regulation::Matchers::Type # Adds matcher where object must match type
Butterfli::Regulation::Conditions::Rate # Adds condition where object must not exceed average rate
Butterfli::Regulation::Throttle # Rule which implements rate condition
```
